### PR TITLE
Updated BOM and CAD (M3x20 / Cover Plate)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ Special thanks to @SanaaHamel, @TubaToothpasties, @Blamm, @Backslash for all the
 - **1x M3x16 SHCS**
     - 1x Air Exhaust Wheel
  
+- **2x M3x20 SHCS**
+    - 2x Mounting
+ 
 - **4x M3x25 SHCS**
     - 2x Lid Front Hinge
     - 2x Mounting


### PR DESCRIPTION
### Updated BOM and CAD (M3x20 / Cover Plate)

**BOM**
- Added missing M3x20 SHCS

**CAD**
- Added missing M3x20 SHCS
- Modified Cover Plate (left old, right new):
![side1](https://github.com/nevermore3d/StealthMax/assets/37146617/258b2a5a-3966-44ce-88d1-29e21a804a74)
![side2](https://github.com/nevermore3d/StealthMax/assets/37146617/bc0ded97-76cd-454b-b33f-ad7841aeaba7)
![top1](https://github.com/nevermore3d/StealthMax/assets/37146617/207eb969-1f07-4767-99d4-dab41111c428)
![top2](https://github.com/nevermore3d/StealthMax/assets/37146617/026dcf88-1c1c-4749-89a6-915a832cd9f4)
